### PR TITLE
Documentation, typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -519,13 +519,15 @@ for smaller file size and to ease installation.
 <ul><details>
 
 The current version of **m100le** (starting with v0.m) uses the New
-York Times Wordle word lists. Previously, the wordfiles used were based
-on the the **original** javascript WORDLE, which contained the entire
-set of daily words (the wordfile) within the program code. Over six
-years worth of words.
+York Times Wordle word lists. That means that every day there is a new
+word chosen and it is the same word for your Model 100 as every other
+computer on the planet. The game, written in Javascript, contains the
+entire set of daily words (the wordfile) within the program code. Over
+six years worth of words.
 
-While the order changed, there are
-[very few differences](https://github.com/jackgreenburg/wordle-wordlists)
+Previously, the wordfiles used were based on the the **original**
+javascript WORDLE. While the order changed, there are [very few
+differences](https://github.com/jackgreenburg/wordle-wordlists)
 between the original and the current word lists.
 
 </details></ul>
@@ -565,6 +567,8 @@ keeps track of the last two digits and the game presumes you are in
 the 21<sup>st</sup> century. For example, if you set
 `DATE$="06/20/26"`, you'll get the same game no matter whether the
 main MENU shows 1926 or 2026.
+</details></ul>
+
 
 ## Feedback
 

--- a/sendfile.md
+++ b/sendfile.md
@@ -5,8 +5,13 @@ Model 100 and no special program is needed. Sending a file to the
 Model 100 is also fairly simple, but the instructions depend upon what
 type of computer you are using.
 
-[Side note: For _binary_ files, you must use a special program, like
-[TEENY](https://youtu.be/H0xx9cOe97s).]
+The rest of this page presumes you have already connected the two
+computers using an 
+[RS232C serial cable](https://www.google.com/search?q=db9f+to+db25m+null) 
+called a "null modem".
+
+_Side note_: For binary (non-ASCII) files, you must use a special program, like
+[TEENY](https://youtu.be/H0xx9cOe97s).
 
 ## Sending from a GNU/Linux UNIX box
 


### PR DESCRIPTION
Oops, I forgot to close a tag at the end and which meant the last part of the README (acknowledgments and authors) wasn't showing up correctly. 