### PR TITLE
Use gsed instead of sed for MacOS

### DIFF
--- a/adjunct/removecomments
+++ b/adjunct/removecomments
@@ -9,6 +9,12 @@
 # Any line which includes two singles quotes in a row will be kept verbatim.
 
 
+# For MacOS, we need gsed to work properly.
+if type gsed >/dev/null 2>&1; then
+    shopt -s expand_aliases
+    alias sed=gsed
+fi
+
 input=${1:-M100LE+comments.DO} # Default file to check if not specified
 output=${2:-/dev/stdout} # Write to stdout if not second file.
 


### PR DESCRIPTION
MacOS doesn't come with gsed, so you'll have to do brew install gnu-sed to get it.

I haven't tested this on MacOS, but it seems to work. 